### PR TITLE
[TASK] Features and bugfixes.

### DIFF
--- a/src/Controller/ControllerCaptcha.php
+++ b/src/Controller/ControllerCaptcha.php
@@ -1,5 +1,6 @@
 <?php
 namespace Pecee\Controller;
+
 use Pecee\Session\Session;
 use Pecee\UI\Form\FormCaptcha;
 

--- a/src/Controller/ControllerRestful.php
+++ b/src/Controller/ControllerRestful.php
@@ -3,7 +3,6 @@ namespace Pecee\Controller;
 
 abstract class ControllerRestful extends Controller {
 
-
     // TODO: rewrite with abstract methods etc.
 
 }

--- a/src/Locale.php
+++ b/src/Locale.php
@@ -20,8 +20,8 @@ class Locale {
 	public function __construct() {
 		// Default stuff
 		$this->setTimezone('Europe/Copenhagen');
-		$this->setLocale('en-UK');
-		$this->setDefaultLocale('en-UK');
+		$this->setLocale('en-gb');
+		$this->setDefaultLocale('en-gb');
 	}
 	/**
 	 * @return string $timezone

--- a/src/Locale.php
+++ b/src/Locale.php
@@ -1,6 +1,8 @@
 <?php
 namespace Pecee;
+
 class Locale {
+    
 	protected static $instance;
 	protected $timezone;
 	protected $defaultLocale;
@@ -23,6 +25,7 @@ class Locale {
 		$this->setLocale('en-gb');
 		$this->setDefaultLocale('en-gb');
 	}
+
 	/**
 	 * @return string $timezone
 	 */
@@ -55,4 +58,5 @@ class Locale {
 	public function setDefaultLocale($defaultLocale) {
 		$this->defaultLocale = $defaultLocale;
 	}
+
 }

--- a/src/Str.php
+++ b/src/Str.php
@@ -2,89 +2,103 @@
 namespace Pecee;
 class Str {
 
-	public static function removeNewlines($input){
-		return preg_replace('/[\n]/', ' ',$input);
-	}
+    public static function removeNewlines($input){
+        return preg_replace('/[\n]/', ' ',$input);
+    }
 
-	public static function removeTabs($input) {
-		return preg_replace('/[\t]/','',$input);
-	}
+    public static function removeTabs($input) {
+        return preg_replace('/[\t]/','',$input);
+    }
 
-	public static function removeEnters($input) {
-		return preg_replace('/[\r]/','',$input);
-	}
+    public static function removeEnters($input) {
+        return preg_replace('/[\r]/','',$input);
+    }
 
-	public static function removeSlashes($string) {
-		return str_replace('\\"', '"', str_replace("\\'", "'", $string));
-	}
+    public static function removeSlashes($string) {
+        return str_replace('\\"', '"', str_replace("\\'", "'", $string));
+    }
 
-	public static function getFirstOrDefault($value, $default = null){
-		return ($value !== null && trim($value) !== '') ? trim($value) : $default;
-	}
+    public static function getFirstOrDefault($value, $default = null){
+        return ($value !== null && trim($value) !== '') ? trim($value) : $default;
+    }
 
-	public static function isUtf8($str) {
+    public static function isUtf8($str) {
         return ($str === mb_convert_encoding(mb_convert_encoding($str, "UTF-32", "UTF-8"), "UTF-8", "UTF-32")) ? true : false;
     }
 
-	public static function substr($text, $maxLength, $end='...', $encoding = 'UTF-8') {
-		if(strlen($text) > $maxLength) {
-			$output = mb_substr($text, 0, $maxLength, $encoding);
-			if(strlen($text) > $maxLength)
-				$output .= $end;
-			return $output;
-		}
-		return $text;
-	}
+    public static function substr($text, $maxLength, $end='...', $encoding = 'UTF-8') {
+        if(strlen($text) > $maxLength) {
+            $output = mb_substr($text, 0, $maxLength, $encoding);
+            if(strlen($text) > $maxLength)
+                $output .= $end;
+            return $output;
+        }
+        return $text;
+    }
 
-	public static function wrap($text, $maxLength = 25) {
-		return preg_replace('/([^\s]{'.$maxLength.'})(?=[^\s])/', '$1', $text);
-	}
+    public static function wrap($text, $maxLength = 25) {
+        return preg_replace('/([^\s]{'.$maxLength.'})(?=[^\s])/', '$1', $text);
+    }
 
-	public static function htmlEntities($value) {
-		if( is_array($value) ) {
-			$newArr = array();
-			foreach($value as $key => $v) {
-				$newArr[$key] = htmlentities($v, null, 'UTF-8');
-			}
-			return $newArr;
-		}
-		return htmlentities($value, ENT_QUOTES, 'UTF-8');
-	}
+    public static function htmlEntities($value) {
+        if( is_array($value) ) {
+            $newArr = array();
+            foreach($value as $key => $v) {
+                $newArr[$key] = htmlentities($v, null, 'UTF-8');
+            }
+            return $newArr;
+        }
+        return htmlentities($value, ENT_QUOTES, 'UTF-8');
+    }
 
-	public static function htmlEntitiesDecode($value) {
-		if( is_array($value) ) {
-			$newArr = array();
-			foreach($value as $key => $v) {
-				$newArr[$key] = html_entity_decode($v, null, 'UTF-8');
-			}
-			return $newArr;
-		}
-		return html_entity_decode($value, ENT_QUOTES, 'UTF-8');
-	}
+    public static function htmlEntitiesDecode($value) {
+        if( is_array($value) ) {
+            $newArr = array();
+            foreach($value as $key => $v) {
+                $newArr[$key] = html_entity_decode($v, null, 'UTF-8');
+            }
+            return $newArr;
+        }
+        return html_entity_decode($value, ENT_QUOTES, 'UTF-8');
+    }
 
-	public static function makeLink($text, $format1='<a href="\\0" rel="nofollow" title="">\\0</a>',
-											$format2='<a href="http://\\2" title="" rel="nofollow">\\2</a>',
-											$format3='<a href="mailto:\\1" title="">\\1</a>') {
-		// match protocol://address/path/
-		$text = preg_replace("/[a-zA-Z]+:\\/\\/([.\\/-]?[a-zA-Z0-9_\\/-\\/&\\/%\\/?\\/=])*/is", $format1, $text);
-		// match www.something
-		$text = preg_replace("/(^|\\s)(www\\.([a-zA-Z0-9_\\/-\\/.])*)/is", $format2, $text);
-		// match me@something.com
-		return preg_replace('/([_\.0-9a-z-]+@([0-9a-z][0-9a-z-]+\.)+[a-z]{2,3})/is', $format3, $text);
-	}
+    public static function makeLink($text, $format1='<a href="\\0" rel="nofollow" title="">\\0</a>',
+                                    $format2='<a href="http://\\2" title="" rel="nofollow">\\2</a>',
+                                    $format3='<a href="mailto:\\1" title="">\\1</a>') {
+        // match protocol://address/path/
+        $text = preg_replace("/[a-zA-Z]+:\\/\\/([.\\/-]?[a-zA-Z0-9_\\/-\\/&\\/%\\/?\\/=])*/is", $format1, $text);
+        // match www.something
+        $text = preg_replace("/(^|\\s)(www\\.([a-zA-Z0-9_\\/-\\/.])*)/is", $format2, $text);
+        // match me@something.com
+        return preg_replace('/([_\.0-9a-z-]+@([0-9a-z][0-9a-z-]+\.)+[a-z]{2,3})/is', $format3, $text);
+    }
 
-	public static function base64Encode($obj) {
-		return base64_encode(serialize($obj));
-	}
+    public static function base64Encode($obj) {
+        return base64_encode(serialize($obj));
+    }
 
-	public static function base64Decode($str, $defaultValue = null) {
-		$req = base64_decode($str);
-		if($req !== FALSE) {
-			$req = unserialize($req);
-			if($req) {
-				return $req;
-			}
-		}
-		return $defaultValue;
-	}
+    public static function base64Decode($str, $defaultValue = null) {
+        $req = base64_decode($str);
+        if($req !== FALSE) {
+            $req = unserialize($req);
+            if($req) {
+                return $req;
+            }
+        }
+        return $defaultValue;
+    }
+
+    public static function decamelize($word) {
+        return preg_replace(
+            '/(^|[a-z])([A-Z])/e',
+            'strtolower(strlen("\\1") ? "\\1_\\2" : "\\2")',
+            $word
+        );
+    }
+
+    public static function camelize($word) {
+        $word = preg_replace('/(^|_)([a-z])/e', 'strtoupper("\\2")', strtolower($word));
+        $word[0] = strtolower($word[0]);
+        return $word;
+    }
 }

--- a/src/UI/Taglib/Taglib.php
+++ b/src/UI/Taglib/Taglib.php
@@ -1,28 +1,38 @@
 <?php
 namespace Pecee\UI\Taglib;
+
 class Taglib {
+
 	const TAG_PREFIX = 'tag';
-	protected $body='';
-	protected $bodies=array();
-	protected $preprocess;
-    protected $currentTag;
-	public function __construct($preprocess = false) {
-        $this->preprocess = $preprocess;
-    }
-	public function callTag($tag, $attrs, $body) {
-        $this->currentTag = $tag;
-		$method = self::TAG_PREFIX.ucfirst($tag);
-        if (!method_exists($this,$method)) {
-        	throw new \Exception('Unknown tag: ' . $tag .' in ' . get_class($this));
-        }
-        $this->body = $body;
-        $this->bodies[] = $body;
-        return $this->$method(((object)$attrs));
+
+	protected $body = '';
+	protected $bodies = array();
+	protected $preProcess;
+	protected $currentTag;
+
+	public function __construct($preProcess = false) {
+		$this->preProcess = $preProcess;
 	}
+
+	public function callTag($tag, $attrs, $body) {
+		$this->currentTag = $tag;
+		$method = self::TAG_PREFIX.ucfirst($tag);
+
+		if (!method_exists($this,$method)) {
+			throw new \Exception('Unknown tag: ' . $tag .' in ' . get_class($this));
+		}
+
+		$this->body = $body;
+		$this->bodies[] = $body;
+
+		return $this->$method(((object)$attrs));
+	}
+
 	public function __call($tag, $args) {
 		$this->callTag($tag, $args[0], $args[1]);
 	}
- 	protected function requireAttributes($attrs, array $name) {
+
+	protected function requireAttributes($attrs, array $name) {
 		$errors = array();
 		foreach($name as $n) {
 			if(!isset($attrs->$n)) {
@@ -33,14 +43,17 @@ class Taglib {
 			throw new \ErrorException('The current tag "'. $this->currentTag .'" requires the attribute(s): '. join(', ', $errors));
 		}
 	}
+
 	public function getBody() {
 		return $this->body;
 	}
+
 	public function setBody($body) {
 		$this->body = $body;
-	}	
-	
-	public function isPreprocess() {
-		return $this->preprocess;
 	}
+
+	public function isPreprocess() {
+		return $this->preProcess;
+	}
+
 }

--- a/src/UI/Taglib/TaglibJs.php
+++ b/src/UI/Taglib/TaglibJs.php
@@ -4,96 +4,184 @@ namespace Pecee\UI\Taglib;
 use Pecee\Str;
 
 class TaglibJs extends Taglib {
-	protected $containers = array();
-	private static $JS_WRAPPER_TAG = '';
-	private static $JS_EXPRESSION = '/js{(.*?)}/';
-	private static $JS_WIDGET_EXPRESSION = '/js{_widget(.*?)}/';
-	protected $output=array();
 
-	public function __construct() {
-		parent::__construct();
-	}
+    protected $containers = array();
 
-	protected function makeJsString($string) {
-		return preg_replace('/[\n\r\t]+|\s\s+/', '', trim($string));
-	}
+    protected static $JS_WRAPPER_TAG = '';
+    protected static $JS_EXPRESSION_START = '/js{/';
+    protected static $JS_WIDGET_EXPRESSION = '/\\$self(.*?)}/';
 
-	protected function replaceJsExpressions($string) {
-		$fixedExpressions=array();
-		$expressionMatches=array();
-		/* Change all widget expressions */
-		$string = preg_replace(self::$JS_WIDGET_EXPRESSION, '$p.getWidget(\'"+g+"\')$1', $string);
-		preg_match_all(self::$JS_EXPRESSION, $string, $expressionMatches);
-		if(count($expressionMatches) > 0) {
-			/* Let's ensure that our js-expression don't get addslashed */
-			foreach($expressionMatches[1] as $match) {
-				$fixedExpressions[] = '"+eval("'.Str::removeSlashes($match).'")+"';
-			}
-			/* Now we replace the expression tags, with the fixed js expression */
-			for($i=0;$i<count($expressionMatches[0]);$i++) {
-				$string = str_replace($expressionMatches[0][$i], $fixedExpressions[$i], $string);
-			}
-		}
-		return $string;
-	}
+    //private static $JS_EXPRESSION = '/js{(.*?)}/';
+    //private static $JS_WIDGET_EXPRESSION_OUTER = '/js{_w(.*?)}/';
+    //private static $JS_WIDGET_EXPRESSION_REPLACEMENT = '';
 
-	protected function tagContainer($attrs) {
-		$this->requireAttributes($attrs, array('id'));
-		$output = sprintf('$.%1$s=function(d,g){var o="<%3$s>%2$s</%3$s>"; return o;};', $attrs->id, $this->makeJsString($this->getBody()), self::$JS_WRAPPER_TAG);
-		$matches=array();
+    public function __construct() {
+        parent::__construct();
+    }
 
-		preg_match_all('%<'.self::$JS_WRAPPER_TAG.'>(.*?)</'.self::$JS_WRAPPER_TAG.'>%', $output, $matches);
-		if(isset($matches[1])) {
-			foreach($matches[1] as $m) {
-				$output = str_replace('<'.self::$JS_WRAPPER_TAG.'>'.$m.'</'.self::$JS_WRAPPER_TAG.'>', addslashes($m), $output);
-			}
-		}
-		$this->containers[$attrs->id] = $this->replaceJsExpressions($output);
-	}
+    protected function makeJsString($string) {
+        return preg_replace('/[\n\r\t]*|\s\s/', '', trim($string));
+    }
 
-	protected function tagIf($attrs) {
-		$this->requireAttributes($attrs, array('test'));
-		return sprintf('</%3$s>";if(%1$s){o+="<%3$s>%2$s</%3$s>"; } o+="<%3$s>', $this->makeJsString($attrs->test), $this->makeJsString($this->getBody()), self::$JS_WRAPPER_TAG);
-	}
+    protected function handleInline($string) {
+        $string = Str::removeSlashes($string);
+        $parts = preg_split('/[;\n]{1,2}/s',$string);
+        if (count($parts) <= 1)
+            return "($string)";
+        $result = "";
+        for($i = 0; $i < count($parts);$i++) {
+            $result .= ($i ==  (count($parts)-1)) ? 'return '.$parts[$i].";" : $parts[$i].";";
+        }
+        return sprintf('(function(){%s})()',$result);
+    }
 
-	protected function tagElse($attrs) {
-		return sprintf('</%2$s>";}else{o+="<%2$s>%s', $this->makeJsString($this->getBody()), self::$JS_WRAPPER_TAG);
-	}
+    protected function replaceJsExpressions($string) {
+        $fixedExpressions = array();
+        $expressionMatches = array();
+        /* Change all widget expressions */
+        $string = preg_replace(self::$JS_WIDGET_EXPRESSION, '$p.getWidget(\'"+g+"\')$1', $string);
+        //$string = preg_replace(self::$JS_WIDGET_EXPRESSION_OUTER, '"+($p.getWidget(g)$1)+"', $string);
+        preg_match_all(self::$JS_EXPRESSION_START, $string, $expressionMatches,PREG_OFFSET_CAPTURE);
 
-	protected function tagElseIf($attrs) {
-		$this->requireAttributes($attrs, array('test'));
-		return sprintf('</%3$s>";}else if(%1$s){o+="<%3$s>%2$s', $attrs->test, $this->makeJsString($this->getBody()), self::$JS_WRAPPER_TAG);
-	}
+        $expressions = array();
+        $mOffset = 0;
 
-	protected function tagWhile($attrs) {
-		$this->requireAttributes($attrs, array('test'));
-		return sprintf('</%3$s>";while(%1$s){o+="<%3$s>%2$s</%3$s>";}o+="<%3$s>', $attrs->test, $this->makeJsString($this->getBody()), self::$JS_WRAPPER_TAG);
-	}
+        foreach($expressionMatches[0] as $match) {
 
-	protected function tagEach($attrs) {
-		$this->requireAttributes($attrs, array('in'));
-		$row = (!isset($attrs->as)) ? 'row' : $attrs->as;
-		$index = (!isset($attrs->index)) ? 'i' : $attrs->index;
-		return sprintf('</%4$s>"; for(var %5$s=0;%5$s<%1$s.length;%5$s++){var %2$s=%1$s[%5$s]; o+="<%4$s>%3$s</%4$s>"; } o+="<%4$s>', $attrs->in, $row, $this->makeJsString($this->getBody()), self::$JS_WRAPPER_TAG, $index);
-	}
+            $mText = $match[0];
+            $offset = $match[1];
+            $searchOffset = $offset+strlen($mText);
+            $curlies = 1;
+            $end = 0;
+            for($i = $searchOffset;$i < strlen($string);$i++) {
+                switch($string[$i]) {
+                    case '{':
+                        $curlies++;
+                        break;
+                    case '}':
+                        $curlies--;
+                        break;
+                }
+                if ($curlies == 0) {
+                    $end = $i;
+                    break;
+                }
+            }
+            if ($end >= $mOffset) {
+                $expressions[] = array(
+                    'raw'=>substr($string,$offset,$end-$offset+1),
+                    'js'=>substr($string,$searchOffset,$end-$searchOffset)
+                );
+            }
 
-	protected function tagFor($attrs) {
-		$this->requireAttributes($attrs, array('limit', 'start', 'in'));
-		return sprintf('</%5$s>";for(var %1$s=%2$s;%1$s<%3$s;%1$s++){o+="<%5$s>%4$s</%5$s>";}o+="<%5$s>', $attrs->in, $attrs->start, $attrs->limit, $this->makeJsString($this->getBody()), self::$JS_WRAPPER_TAG);
-	}
+        }
 
-	protected function tagBreak() {
-		return sprintf('</%1$s>"; break; o+="<%1$s>', self::$JS_WRAPPER_TAG);
-	}
+        if(count($expressions) > 0) {
+            /* Let's ensure that our js-expression don't get addslashed */
+            foreach($expressions as $expr) {
+                $fixedExpressions[] = '"+'.$this->handleInline($expr['js']).'+"';
+            }
 
-	protected function tagCollect($attrs) {
-		$output = array('<!-- JSTaglib start --><script>');
-		if($this->containers) {
-			foreach($this->containers as $c) {
-				$output[] = $c;
-			}
-		}
-		$output[] = '</script><!-- JSTaglib end -->';
-		return join('', $output);
-	}
+            /* Now we replace the expression tags, with the fixed js expression */
+            for($i=0;$i<count($expressions);$i++) {
+                $string = str_replace($expressions[$i]['raw'],$fixedExpressions[$i], $string);
+            }
+        }
+        return $string;
+    }
+
+    protected function tagContainer($attrs) {
+        $this->requireAttributes($attrs, array('id'));
+
+        $output = sprintf('$.%1$s = new $p.template(); $.%1$s.view = function(d,g){var o="<%3$s>%2$s</%3$s>"; return o;};', $attrs->id, $this->makeJsString($this->getBody()), self::$JS_WRAPPER_TAG);
+        $matches = array();
+
+        preg_match_all('%<'.self::$JS_WRAPPER_TAG.'>(.*?)</'.self::$JS_WRAPPER_TAG.'>%', $output, $matches);
+        if(isset($matches[1])) {
+            foreach($matches[1] as $m) {
+                $output = str_replace('<'.self::$JS_WRAPPER_TAG.'>'.$m.'</'.self::$JS_WRAPPER_TAG.'>', addslashes($m), $output);
+            }
+        }
+
+        $this->containers[$attrs->id] = $this->replaceJsExpressions($output);
+
+        if(env('DEBUG')) {
+            $this->containers[$attrs->id] = str_replace('o+=', "\no+=", $this->containers[$attrs->id]);
+            $this->containers[$attrs->id] = preg_replace('/";(\}else\{|for|if]switch)/i', "\";\n$1", $this->containers[$attrs->id]);
+        }
+    }
+
+    protected function tagIf($attrs) {
+        $this->requireAttributes($attrs, array('test'));
+        return sprintf('</%3$s>";if(%1$s){o+="<%3$s>%2$s</%3$s>"; } o+="<%3$s>', $this->makeJsString($attrs->test), $this->getBody(), self::$JS_WRAPPER_TAG);
+    }
+
+    protected function tagElse() {
+        return sprintf('</%2$s>";}else{o+="<%2$s>%s', $this->makeJsString($this->getBody()), self::$JS_WRAPPER_TAG);
+    }
+
+    protected function tagElseIf($attrs) {
+        $this->requireAttributes($attrs, array('test'));
+        return sprintf('</%3$s>";}else if(%1$s){o+="<%3$s>%2$s', $attrs->test, $this->makeJsString($this->getBody()), self::$JS_WRAPPER_TAG);
+    }
+
+    protected function tagWhile($attrs) {
+        $this->requireAttributes($attrs, array('test'));
+        return sprintf('</%3$s>";while(%1$s){o+="<%3$s>%2$s</%3$s>";}o+="<%3$s>', $attrs->test, $this->makeJsString($this->getBody()), self::$JS_WRAPPER_TAG);
+    }
+
+    protected function tagBind($attrs) {
+        $this->requireAttributes($attrs, array('name'));
+
+        $output = sprintf('<%1$s>'.$this->makeJsString($this->getBody()).'</%1$s>', self::$JS_WRAPPER_TAG);
+
+        preg_match_all('%<'.self::$JS_WRAPPER_TAG.'>(.*?)</'.self::$JS_WRAPPER_TAG.'>%', $output, $matches);
+        if(isset($matches[1])) {
+            foreach($matches[1] as $m) {
+                $output = str_replace('<'.self::$JS_WRAPPER_TAG.'>'.$m.'</'.self::$JS_WRAPPER_TAG.'>', addslashes($m), $output);
+            }
+        }
+
+        $output = $this->replaceJsExpressions($output);
+
+        if(env('DEBUG')) {
+            $output = str_replace('o+=', "\no+=", $output);
+            $output = preg_replace('/";(\}else\{|for|if]switch)/i', "\";\n$1", $output);
+        }
+
+        $data = (isset($attrs->data)) ? $attrs->data : 'null';
+        $el = (isset($attrs->el)) ? $attrs->el : 'div';
+
+        return sprintf('</%5$s>"; var guid = $p.utils.generateGuid(); var key="%1$s"; this.bindings[key]={}; this.bindings[key].guid = guid;  this.bindings[key].callback=function(d){ var id = this.guid; var o = "%4$s"; $("#" + id).html(o); }; this.bindings[key].data = %3$s; o += "<%2$s id=\""+ guid +"\"></%2$s>"; o+="<%5$s>', $attrs->name, $el, $data, $output, self::$JS_WRAPPER_TAG);
+    }
+
+    protected function tagEach($attrs) {
+        $this->requireAttributes($attrs, array('in'));
+        $row = (!isset($attrs->as)) ? 'row' : $attrs->as;
+        $index = (!isset($attrs->index)) ? 'i' : $attrs->index;
+        return sprintf('</%4$s>"; for(var %5$s=0;%5$s<%1$s.length;%5$s++){var %2$s=%1$s[%5$s]; o+="<%4$s>%3$s</%4$s>"; } o+="<%4$s>', $attrs->in, $row, $this->makeJsString($this->getBody()), self::$JS_WRAPPER_TAG, $index);
+    }
+
+    protected function tagFor($attrs) {
+        $this->requireAttributes($attrs, array('limit', 'start', 'it'));
+        return sprintf('</%5$s>";for(var %1$s=%2$s;%1$s<%3$s;%1$s++){o+="<%5$s>%4$s</%5$s>";}o+="<%5$s>', $attrs->it, $attrs->start, $attrs->limit, $this->makeJsString($this->getBody()), self::$JS_WRAPPER_TAG);
+    }
+
+    protected function tagBreak() {
+        return sprintf('</%1$s>"; break; o+="<%1$s>', self::$JS_WRAPPER_TAG);
+    }
+
+    protected function tagCollect() {
+        $output = array('<!-- JSTaglib start --><script>');
+
+        if($this->containers) {
+            foreach($this->containers as $c) {
+                $output[] = $c;
+            }
+        }
+
+        $output[] = '</script><!-- JSTaglib -->';
+        return join('', $output);
+    }
+
 }

--- a/src/Web/YUICompressor/YUICompressor.php
+++ b/src/Web/YUICompressor/YUICompressor.php
@@ -45,7 +45,7 @@ class YUICompressor {
     	$this->addItem($type, $content, $options);
     }
 
-    private function addItem($type,$content,$options,$filename=null,$filepath=null) {
+    protected function addItem($type,$content,$options,$filename=null,$filepath=null) {
     	$item = new YUICompressorItem();
     	$item->type=$type;
     	$item->content=$content;
@@ -77,13 +77,14 @@ class YUICompressor {
         }
         return ($single) ? $this->items[count($this->items)-1] : $this->items;
     }
-	private function validateType($type) {
+
+    protected function validateType($type) {
     	if(!in_array($type, $this->types)) {
     		throw new YUICompressorException('Unknown type: '.$type.'. Type must be one of the following: ' . join($this->types, ', '));
     	}
     }
 
-    private function getCmd($userOptions, $type, $tmpFile) {
+    protected function getCmd($userOptions, $type, $tmpFile) {
         $o = array_merge(
             array(
                 'charset' => ''
@@ -108,21 +109,27 @@ class YUICompressor {
 	public function getJarFile() {
 		return $this->jarFile;
 	}
+
 	public function getTempDir() {
 		return $this->tempDir;
 	}
+
 	public function getJavaExecutable() {
 		return $this->javaExecutable;
 	}
+
 	public function setJarFile($jarFile) {
 		$this->jarFile = $jarFile;
 	}
+
 	public function setTempDir($tempDir) {
 		$this->tempDir = $tempDir;
 	}
+
 	public function setJavaExecutable($javaExecutable) {
 		$this->javaExecutable = $javaExecutable;
 	}
+
 	public function getItems() {
 		return $this->items;
 	}

--- a/src/Web/YUICompressor/YUICompressorItem.php
+++ b/src/Web/YUICompressor/YUICompressorItem.php
@@ -1,5 +1,6 @@
 <?php
 namespace Pecee\Web\YUICompressor;
+
 class YUICompressorItem {
 	public $filename;
 	public $filepath;

--- a/src/Xml/IXmlNode.php
+++ b/src/Xml/IXmlNode.php
@@ -1,13 +1,17 @@
 <?php
 namespace Pecee\Xml;
 interface IXmlNode {
+
 	public function __toString();
+
 	/**
 	 * @param XmlElement $parent
 	*/
 	public function setParent($parent);
+
 	/**
 	 * @return XmlElement
 	*/
 	public function getParent();
+
 }

--- a/src/Xml/Translate/Translate.php
+++ b/src/Xml/Translate/Translate.php
@@ -18,10 +18,10 @@ class Translate {
 	}
 
 	protected $xml;
-    protected $dir;
+	protected $dir;
 
 	public function __construct() {
-        $this->dir = '../lang';
+		$this->dir = '../lang';
 		$this->setLanguageXml();
 	}
 
@@ -29,39 +29,43 @@ class Translate {
 		if(!$this->dir) {
 			throw new TranslateException('XML language directory must be specified.');
 		}
+
 		$xml=new \SimpleXmlElement($this->xml);
 		$node=null;
-		if(strpos($key, '/') > -1) {
-			$children=explode('/', $key);
+
+		if(strpos($key, '.') > -1) {
+			$children = explode('.', $key);
 			foreach($children as $i=>$child) {
-				if($i==0) {
-					$node=(isset($xml->$child) ? $xml->$child : null);
+				if($i === 0) {
+					$node = (isset($xml->$child) ? $xml->$child : null);
 				} else {
-					$node=(isset($node->$child) ? $node->$child : null);
+					$node = (isset($node->$child) ? $node->$child : null);
 				}
 			}
 		} else {
 			$node=isset($xml->$key) ? $xml->$key : null;
 		}
+
 		if(!is_null($node)) {
 			return $node;
 		}
+
 		throw new TranslateException(sprintf('Key "%s" does not exist for locale "%s"', $key, Locale::getInstance()->getLocale()));
 	}
 
 	public function setLanguageXml() {
-		$path = sprintf('%s/%s.xml', $this->dir, strtolower(Locale::getInstance()->getLocale()));
+		$path = sprintf('%s/%s.xml', $this->dir, str_replace('-', '_', strtolower(Locale::getInstance()->getLocale())));
 		if(!file_exists($path)) {
 			throw new TranslateException(sprintf('Language file %s not found for locale %s', $path, Locale::getInstance()->getLocale()));
 		}
-		$this->xml=file_get_contents($path);
+		$this->xml = file_get_contents($path, FILE_USE_INCLUDE_PATH);
 	}
 
-    public function setDirectory($dir) {
-        $this->dir = $dir;
-    }
+	public function setDirectory($dir) {
+		$this->dir = $dir;
+	}
 
-    public function getDir() {
-        return $this->dir;
-    }
+	public function getDir() {
+		return $this->dir;
+	}
 }

--- a/src/Xml/Xml.php
+++ b/src/Xml/Xml.php
@@ -2,10 +2,11 @@
 namespace Pecee\Xml;
 class Xml {
 	public static function toXml($data,$parent = 'root') {
-		
+
 		if (!($parent instanceof IXmlNode)) {
 			$parent = new XmlElement((string)$parent);
 		}
+
 		switch(true) {
 			case is_array($data):
 			case is_object($data):
@@ -45,6 +46,7 @@ class Xml {
 				$parent->addChild(new XmlText($data));
 				break;
 		}
+
 		return $parent;
 	}
 }

--- a/src/Xml/XmlElement.php
+++ b/src/Xml/XmlElement.php
@@ -82,6 +82,7 @@ class XmlElement implements IXmlNode {
 	public function getChildIndex(IXmlNode $node) {
 		return array_search($node,$this->children);
 	}
+
 	public function setChildAt($i,IXmlNode $node) {
 		if ($i < 0 || $i > count($this->children))
 			throw new \Exception ("Child offset out of bounds: $i. Child count : ".count($this->children));
@@ -90,6 +91,7 @@ class XmlElement implements IXmlNode {
 		ksort($this->children);
 		return $this;
 	}
+
 	public function removeChildAt($i) {
 		if ($i < 0 || $i > count($this->children))
 			throw new \Exception ("Child offset out of bounds: $i. Child count : ".count($this->children));
@@ -97,9 +99,11 @@ class XmlElement implements IXmlNode {
 		$this->children = array_values($this->children);
 		return $this;
 	}
+
 	public function removeChild(IXmlNode $node) {
 		return $this->removeChildAt($this->getChildIndex($node));
 	}
+
 	public function addChildAt($offset,IXmlNode $node) {
 		if ($offset < 0)
 			throw new \Exception ("Child offset must be greater than -1".count($this->children));
@@ -118,11 +122,13 @@ class XmlElement implements IXmlNode {
 		$this->children = $result;
 		return $this;
 	}
+
 	public function addChildren($children) {
 		foreach($children as $node) {
 			$this->addChild($node);
 		}
 	}
+
 	public function addChildrenAt($offset,$children) {
 		$i = 0;
 		foreach($children as $node) {
@@ -130,9 +136,11 @@ class XmlElement implements IXmlNode {
 			$i++;
 		}
 	}
+
 	public function detach() {
 		$this->getParent()->removeChild($this);
 	}
+
 	/**
 	 * replace node with other node
 	 */
@@ -142,6 +150,7 @@ class XmlElement implements IXmlNode {
 		$this->detach();
 		$parent->addChildAt($i,$otherNode);
 	}
+
 	public function clear() {
 		foreach ($this->children as $child) {
 			$child->setParent(null);
@@ -162,6 +171,7 @@ class XmlElement implements IXmlNode {
 		}
 		return $result;
 	}
+
 	public function toXml($makeParent = true) {
 		$str = "";
 		if (!$this->parent && $makeParent) {
@@ -191,4 +201,5 @@ class XmlElement implements IXmlNode {
 		}
 		return $str;
 	}
+
 }

--- a/src/Xml/XmlText.php
+++ b/src/Xml/XmlText.php
@@ -2,10 +2,10 @@
 namespace Pecee\Xml;
 
 class XmlText implements IXmlNode {
-	private $parent;
-	private $text = '';
+	protected $parent;
+    protected $text = '';
 
-	function __construct($text) {
+	public function __construct($text) {
 		$this->text = $text;
 	}
 
@@ -28,7 +28,9 @@ class XmlText implements IXmlNode {
 	public function __toString() {
 		return $this->text;
 	}
+
 	public function toXml() {
 		return $this->text;
 	}
+
 }


### PR DESCRIPTION
- Added ```camelize``` method to ```Str``` class.
- Added ```decamelize``` method to ```Str``` class.
- Fixed error causing ```fetchAllPage``` method to render count value twice.
- Added ```rename``` for easy renaming of table columns.
- All ```TaglibJs``` views are now inherited from ```$p.template``` namespace from ```pecee-widget.js```.
- When debug mode is enabled, ```TaglibJs``` will now display output with newlines for easier debugging.
- Added ```<js:bind>``` tag in ```TaglibJs``` to support easier dom-refresh of items.
- Optimised ```Taglib``` class.
- Changed ```/``` identifier to ```.``` for traversing translations.
- Changed default locale to ```en-gb```.
- Fixed translation xml not found in some occasions.
- Optimisations.