### PR TITLE
[BUGFIX] ModelNode + ModelUser no longer saves data which contains null

### DIFF
--- a/src/Model/ModelFile.php
+++ b/src/Model/ModelFile.php
@@ -71,7 +71,7 @@ class ModelFile extends ModelData {
 			/* Remove all fields */
 			FileData::removeAll($this->id);
 			foreach($this->data->getData() as $key=>$value) {
-				$data=new FileData($this->id, $key, $value);
+				$data  =new FileData($this->id, $key, $value);
 				$data->save();
 			}
 		}

--- a/src/Model/ModelNode.php
+++ b/src/Model/ModelNode.php
@@ -190,7 +190,7 @@ class ModelNode extends Model {
     }
 
     public function updateFields() {
-        if($this->data) {
+        if($this->data !== null) {
 
             $currentFields = NodeData::getByNodeId($this->id);
 
@@ -203,6 +203,11 @@ class ModelNode extends Model {
                 foreach($this->data->getData() as $key=>$value) {
 
                     if(isset($cf[strtolower($key)])) {
+
+                        if($cf[$key]->value === null) {
+                            continue;
+                        }
+
                         if($cf[$key]->value === $value) {
                             unset($cf[$key]);
                             continue;

--- a/src/Model/ModelUser.php
+++ b/src/Model/ModelUser.php
@@ -63,7 +63,7 @@ class ModelUser extends ModelData {
 
     public function updateData() {
 
-        if($this->data) {
+        if($this->data !== null) {
 
             $currentFields = UserData::getByUserId($this->id);
 
@@ -72,21 +72,27 @@ class ModelUser extends ModelData {
                 $cf[strtolower($field->key)] = $field;
             }
 
-            if(count($this->data->getData()) > 0) {
+            if(count($this->data->getData())) {
                 foreach($this->data->getData() as $key=>$value) {
 
                     if(isset($cf[strtolower($key)])) {
-                        if($cf[$key]->value == $value) {
+
+                        if($cf[$key]->value === null) {
+                            continue;
+                        }
+
+                        if($cf[$key]->value === $value) {
                             unset($cf[$key]);
                             continue;
                         } else {
                             $cf[$key]->value = $value;
+                            $cf[$key]->key = $key;
                             $cf[$key]->update();
                             unset($cf[$key]);
                         }
                     } else {
                         $field = new UserData();
-                        $field->user_id = $this->id;
+                        $field->node_id = $this->id;
                         $field->key = $key;
                         $field->value = $value;
                         $field->save();


### PR DESCRIPTION
- ```ModelNode``` and ```ModelUser``` class no longer saves data which contains ```null``` value.