### PR TITLE
[BUGFIX] Fixed node_id being set instead of user_id.

### DIFF
--- a/src/Model/ModelUser.php
+++ b/src/Model/ModelUser.php
@@ -92,7 +92,7 @@ class ModelUser extends ModelData {
                         }
                     } else {
                         $field = new UserData();
-                        $field->node_id = $this->id;
+                        $field->user_id = $this->id;
                         $field->key = $key;
                         $field->value = $value;
                         $field->save();


### PR DESCRIPTION
- Fixed ```node_id``` being set instead of ```user_id``` in ```ModelUser``` class.