### PR TITLE
V3 development

### DIFF
--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -296,11 +296,7 @@ abstract class Model implements \IteratorAggregate {
 
     public function getArray(){
 
-        if($this->isCollection()) {
-            if(!$this->hasRows()) {
-                return array();
-            }
-        } else {
+        if(!$this->isCollection()) {
             if(!$this->hasRow()) {
                 return null;
             }

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -13,7 +13,11 @@ abstract class Model implements \IteratorAggregate {
     protected $results;
 
     protected $primary = 'id';
-    protected $hidden, $with, $rename, $join, $columns = [];
+    protected $hidden = [];
+    protected $with = [];
+    protected $rename = [];
+    protected $join = [];
+    protected $columns = [];
 
     public function __construct() {
         // Set table name if its not already defined
@@ -127,11 +131,11 @@ abstract class Model implements \IteratorAggregate {
         $sql = PdoHelper::formatQuery($query, $args);
         $query =  Pdo::getInstance()->query($sql);
 
-        $results['data']['numFields'] = $query->columnCount();
-        $results['data']['numRows'] = $query->rowCount();
+        $results['data']['max_fields'] = $query->columnCount();
+        $results['data']['max_rows'] = $query->rowCount();
         $results['query'] = array($sql);
         $results['data']['rows'] = array();
-        if($results['data']['numRows'] > 0) {
+        if($results['data']['max_rows'] > 0) {
             foreach($query->fetchAll(\PDO::FETCH_ASSOC) as $row) {
                 $obj = static::onCreateModel(new CollectionItem($row));
                 $obj->setRows($row);
@@ -144,12 +148,8 @@ abstract class Model implements \IteratorAggregate {
             $results['query'][] = $countSql;
             $maxRows = Pdo::getInstance()->value($countSql);
             $results['data']['page'] = $page;
-            $results['data']['rowsPerPage'] = $rows;
-            $results['data']['maxRows'] = intval($maxRows);
-        } else {
-            $results['data']['page'] = 0;
-            $results['data']['rowsPerPage'] = null;
-            $results['data']['maxRows'] = intval($results['data']['numRows']);
+            $results['data']['rows_per_page'] = $rows;
+            $results['data']['max_rows'] = intval($maxRows);
         }
 
         $model->setResults($results);
@@ -166,11 +166,11 @@ abstract class Model implements \IteratorAggregate {
         $query =  Pdo::getInstance()->query($sql);
 
         if($query !== null) {
-            $results['data']['numFields'] = $query->columnCount();
-            $results['data']['numRows'] = $query->rowCount();
+            $results['data']['max_fields'] = $query->columnCount();
+            $results['data']['max_rows'] = $query->rowCount();
             $results['query'] = $sql;
             $results['data']['rows'] = array();
-            if($results['data']['numRows'] > 0) {
+            if($results['data']['max_rows'] > 0) {
                 foreach($query->fetchAll(\PDO::FETCH_ASSOC) as $row) {
                     $obj = static::onCreateModel(new CollectionItem($row));
                     $obj->setRows($row);
@@ -218,8 +218,8 @@ abstract class Model implements \IteratorAggregate {
         }
         $model = static::queryCollection($query, null, null, $args);
         $results = $model->getResults();
-        $results['data']['rowsPerPage'] = $rows;
-        $results['data']['hasPrevious'] = ($skip > 0);
+        $results['data']['rows_per_page'] = $rows;
+        $results['data']['has_previous'] = ($skip > 0);
         $model->setResults($results);
         return $model;
     }
@@ -272,7 +272,7 @@ abstract class Model implements \IteratorAggregate {
     }
 
     public function isCollection() {
-        return (array_key_exists('rowsPerPage', $this->results['data']));
+        return (array_key_exists('rows_per_page', $this->results['data']));
     }
 
     protected function parseArrayData($data) {
@@ -300,7 +300,7 @@ abstract class Model implements \IteratorAggregate {
         }
 
         $arr = array('rows' => null);
-        $arr = array_merge($arr, (array)$this->results['data']);
+        $arr = array_merge($arr, $this->results['data']);
         $rows = $this->results['data']['rows'];
         if($rows && is_array($rows)) {
             foreach($rows as $key=>$row){
@@ -320,8 +320,10 @@ abstract class Model implements \IteratorAggregate {
                 }
             }
 
-            $arr['hasNext'] = $this->hasNext();
-            $arr['hasPrevious'] = $this->hasPrevious();
+            if($this->isCollection()) {
+                $arr['has_next'] = $this->hasNext();
+                $arr['has_previous'] = $this->hasPrevious();
+            }
         }
 
         if(count($this->getResults()) === 1) {
@@ -372,8 +374,8 @@ abstract class Model implements \IteratorAggregate {
     }
 
     public function setRows(array $rows) {
-        if(!isset($this->results['data']['numRows'])) {
-            $this->results['data']['numRows'] = count($rows);
+        if(!isset($this->results['data']['max_rows'])) {
+            $this->results['data']['max_rows'] = count($rows);
         }
         $this->results['data']['rows'] = $rows;
         $this->results['data']['original'] = $rows;
@@ -395,11 +397,11 @@ abstract class Model implements \IteratorAggregate {
     }
 
     public function getMaxRows() {
-        return isset($this->results['data']['maxRows']) ? $this->results['data']['maxRows'] : 0;
+        return isset($this->results['data']['max_rows']) ? $this->results['data']['max_rows'] : 0;
     }
 
     public function setMaxRows($rows) {
-        $this->results['data']['maxRows'] = $rows;
+        $this->results['data']['max_rows'] = $rows;
     }
 
     public function getMaxPages() {
@@ -411,11 +413,11 @@ abstract class Model implements \IteratorAggregate {
     }
 
     public function getRowsPerPage() {
-        return isset($this->results['data']['rowsPerPage']) ? $this->results['data']['rowsPerPage'] : 0;
+        return isset($this->results['data']['rows_per_page']) ? $this->results['data']['rows_per_page'] : 0;
     }
 
     public function setRowsPerPage($rows) {
-        $this->results['data']['rowsPerPage'] = $rows;
+        $this->results['data']['rows_per_page'] = $rows;
     }
 
     public function getPage() {

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -272,7 +272,7 @@ abstract class Model implements \IteratorAggregate {
     }
 
     public function isCollection() {
-        return (array_key_exists('rows_per_page', $this->results['data']));
+        return (array_key_exists('max_rows', $this->results['data']));
     }
 
     protected function parseArrayData($data) {
@@ -296,7 +296,7 @@ abstract class Model implements \IteratorAggregate {
 
     public function getArray(){
         if(!$this->hasRows() && !$this->isCollection()) {
-            return null;
+            return array();
         }
 
         $arr = array('rows' => null);

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -295,8 +295,15 @@ abstract class Model implements \IteratorAggregate {
     }
 
     public function getArray(){
-        if(!$this->hasRows() && !$this->isCollection()) {
-            return array();
+
+        if($this->isCollection()) {
+            if(!$this->hasRows()) {
+                return array();
+            }
+        } else {
+            if(!$this->hasRow()) {
+                return null;
+            }
         }
 
         $arr = array('rows' => null);

--- a/src/Model/User/UserReset.php
+++ b/src/Model/User/UserReset.php
@@ -45,13 +45,13 @@ class UserReset extends Model {
         if($reset->hasRow()) {
             $reset->delete();
             self::nonQuery('DELETE FROM {table} WHERE `'. static::USER_IDENTIFIER_KEY . '` = %s', $reset->{static::USER_IDENTIFIER_KEY});
-            return $reset->user_id;
+            return $reset->{static::USER_IDENTIFIER_KEY};
         }
         return false;
     }
 
-    public function getUserId() {
-        return $this->user_id;
+    public function getIdentifier() {
+        return $this->{static::USER_IDENTIFIER_KEY};
     }
 
     public function getKey() {

--- a/src/UI/Form/Form.php
+++ b/src/UI/Form/Form.php
@@ -4,7 +4,6 @@ namespace Pecee\UI\Form;
 use Pecee\Boolean;
 use Pecee\Dataset\Dataset;
 use Pecee\Http\Input\Input;
-use Pecee\Str;
 use Pecee\UI\Html\Html;
 use Pecee\UI\Html\HtmlCheckbox;
 use Pecee\UI\Html\HtmlForm;
@@ -15,6 +14,7 @@ use Pecee\UI\Html\HtmlSelectOption;
 use Pecee\UI\Html\HtmlTextarea;
 
 class Form {
+    
     const FORM_ENCTYPE_FORM_DATA = 'multipart/form-data';
 
     protected $input;
@@ -74,7 +74,7 @@ class Form {
         if($saveValue && (is_null($value) && $this->getValue($name) || request()->getMethod() !== 'get')) {
             $value = $this->getValue($name);
         }
-        return new HtmlInput($name, $type, Str::htmlEntities($value));
+        return new HtmlInput($name, $type, $value);
     }
 
     /**
@@ -207,7 +207,7 @@ class Form {
     public function button($text, $type = null, $name = null, $value = null) {
         $el = new Html('button');
 
-        $el->setInnerHtml($text);
+        $el->addInnerHtml($text);
 
         if($type !== null) {
             $el->addAttribute('type', $type);
@@ -232,5 +232,5 @@ class Form {
     public function end() {
         return '</form>';
     }
-    
+
 }

--- a/src/UI/Html/Html.php
+++ b/src/UI/Html/Html.php
@@ -133,4 +133,13 @@ class Html {
     public function getInnerHtml() {
         return $this->innerHtml;
     }
+
+    public function getAttribute($name) {
+        return (isset($this->attributes[$name]) ? $this->attributes[$name] : null);
+    }
+
+    public function getAttributes() {
+        return $this->attributes;
+    }
+
 }

--- a/src/UI/Html/Html.php
+++ b/src/UI/Html/Html.php
@@ -6,30 +6,30 @@ use Pecee\Widget\Widget;
 
 class Html {
 
-	protected $type;
-	protected $innerHtml;
-	protected $closingType;
-	protected $attributes;
+    protected $type;
+    protected $innerHtml;
+    protected $closingType;
+    protected $attributes;
 
-	const CLOSE_TYPE_SELF = 'self';
-	const CLOSE_TYPE_TAG = 'tag';
-	const CLOSE_TYPE_NONE = 'none';
+    const CLOSE_TYPE_SELF = 'self';
+    const CLOSE_TYPE_TAG = 'tag';
+    const CLOSE_TYPE_NONE = 'none';
 
-	public function __construct($type) {
-		$this->type = $type;
-		$this->attributes = array();
-		$this->closingType = self::CLOSE_TYPE_TAG;
-		$this->innerHtml = array();
-	}
+    public function __construct($type) {
+        $this->type = $type;
+        $this->attributes = array();
+        $this->closingType = self::CLOSE_TYPE_TAG;
+        $this->innerHtml = array();
+    }
 
-	/**
-	 * @param array $html
+    /**
+     * @param array $html
      * @return self
-	 */
-	public function setInnerHtml(array $html) {
-		$this->innerHtml = $html;
+     */
+    public function setInnerHtml(array $html) {
+        $this->innerHtml = $html;
         return $this;
-	}
+    }
 
 
     public function addInnerHtml($html) {
@@ -37,88 +37,98 @@ class Html {
         return $this;
     }
 
-	public function addWidget(Widget $widget) {
-		return $this->addInnerHtml($widget->__toString());
-	}
+    public function addWidget(Widget $widget) {
+        return $this->addInnerHtml($widget->__toString());
+    }
 
-	public function addMenu(Menu $menu) {
-		return $this->addInnerHtml($menu->__toString());
-	}
+    public function addMenu(Menu $menu) {
+        return $this->addInnerHtml($menu->__toString());
+    }
 
-	public function addItem(Html $htmlItem) {
-		return $this->addInnerHtml($htmlItem->__toString());
-	}
+    public function addItem(Html $htmlItem) {
+        return $this->addInnerHtml($htmlItem->__toString());
+    }
 
-	/**
-	 * Adds new attribute to the element.
-	 *
-	 * @param string $name
-	 * @param string $value
-	 * @return static
-	 */
-	public function addAttribute($name, $value='') {
-		$this->attributes[$name] = $value;
-		return $this;
-	}
+    /**
+     * Adds new attribute to the element.
+     *
+     * @param string $name
+     * @param string $value
+     * @return static
+     */
+    public function addAttribute($name, $value = '') {
+        if(!isset($this->attributes[$name])) {
+            $this->attributes[$name] = array($value);
+        } else {
+            foreach($this->attributes[$name] as $val) {
+                if($val === $value) {
+                    return $this;
+                }
+            }
+            $this->attributes[$name][] = $value;
+        }
 
-	public function attr($name, $value = '') {
-		return $this->addAttribute($name, $value);
-	}
+        return $this;
+    }
 
-	public function id($id) {
-		$this->attr('id', $id);
-		return $this;
-	}
+    public function attr($name, $value = '') {
+        return $this->addAttribute($name, $value);
+    }
 
-	public function style($css) {
-		$this->attr('style', $css);
-		return $this;
-	}
+    public function id($id) {
+        $this->attr('id', $id);
+        return $this;
+    }
 
-	protected function writeHtml() {
-		$output = '<'.$this->type;
-		foreach($this->attributes as $key=>$val) {
-			$output .= ' '.$key. (($val !== null || strtolower($key) === 'value') ? '="'.$val.'"' : '');
-		}
-		$output .= ($this->closingType === self::CLOSE_TYPE_SELF) ? '/>' : '>';
+    public function style($css) {
+        $this->attr('style', $css);
+        return $this;
+    }
+
+    protected function writeHtml() {
+        $output = '<'.$this->type;
+        foreach($this->attributes as $key =>  $val) {
+            $output .= ' '.$key. (($val !== null || strtolower($key) === 'value') ? '="' . join(' ', $val) . '"' : '');
+        }
+        $output .= ($this->closingType === self::CLOSE_TYPE_SELF) ? '/>' : '>';
         foreach($this->innerHtml as $html) {
             $output.=$html;
         }
-		$output .= (($this->closingType === self::CLOSE_TYPE_TAG) ? sprintf('</%s>',$this->type) : '');
-		return $output;
-	}
+        $output .= (($this->closingType === self::CLOSE_TYPE_TAG) ? sprintf('</%s>',$this->type) : '');
+        return $output;
+    }
 
-	/**
-	 * Add class
-	 * @param string $class
+    /**
+     * Add class
+     * @param string $class
      * @return static
-	 */
-	public function addClass($class) {
-		$this->addAttribute('class',$class);
-		return $this;
-	}
+     */
+    public function addClass($class) {
+        $this->addAttribute('class', $class);
+        return $this;
+    }
 
-	/**
-	 * @return string $closingType
-	 */
-	public function getClosingType() {
-		return $this->closingType;
-	}
+    /**
+     * @return string $closingType
+     */
+    public function getClosingType() {
+        return $this->closingType;
+    }
 
-	public function getType() {
-		return $this->type;
-	}
+    public function getType() {
+        return $this->type;
+    }
 
-	/**
-	 * @param string $closingType
-	 */
-	public function setClosingType($closingType) {
-		$this->closingType = $closingType;
-	}
+    /**
+     * @param string $closingType
+     */
+    public function setClosingType($closingType) {
+        $this->closingType = $closingType;
+    }
 
-	public function __toString() {
-		return $this->writeHtml();
-	}
+    public function __toString() {
+        return $this->writeHtml();
+    }
 
     public function getInnerHtml() {
         return $this->innerHtml;

--- a/src/UI/Html/Html.php
+++ b/src/UI/Html/Html.php
@@ -5,45 +5,48 @@ use Pecee\UI\Menu\Menu;
 use Pecee\Widget\Widget;
 
 class Html {
-	protected $name;
-	protected $value;
+
+	protected $type;
 	protected $innerHtml;
 	protected $closingType;
 	protected $attributes;
 
-	const CLOSE_TYPE_SELF='self';
-	const CLOSE_TYPE_TAG='tag';
-	const CLOSE_TYPE_NONE='none';
+	const CLOSE_TYPE_SELF = 'self';
+	const CLOSE_TYPE_TAG = 'tag';
+	const CLOSE_TYPE_NONE = 'none';
 
-	public function __construct($name, $value = null) {
-		$this->name = $name;
-		$this->value = $value;
+	public function __construct($type) {
+		$this->type = $type;
 		$this->attributes = array();
 		$this->closingType = self::CLOSE_TYPE_TAG;
 		$this->innerHtml = array();
 	}
 
 	/**
-	 * @param string $innerHtml
+	 * @param array $html
+     * @return self
 	 */
-	public function setInnerHtml($innerHtml) {
-		$this->innerHtml[] = $innerHtml;
+	public function setInnerHtml(array $html) {
+		$this->innerHtml = $html;
+        return $this;
 	}
 
+
+    public function addInnerHtml($html) {
+        $this->innerHtml[] = $html;
+        return $this;
+    }
+
 	public function addWidget(Widget $widget) {
-		$this->setInnerHtml($widget->__toString());
+		return $this->addInnerHtml($widget->__toString());
 	}
 
 	public function addMenu(Menu $menu) {
-		$this->setInnerHtml($menu->__toString());
+		return $this->addInnerHtml($menu->__toString());
 	}
 
 	public function addItem(Html $htmlItem) {
-		$this->setInnerHtml($htmlItem->__toString());
-	}
-
-	public function setElement(Html $el) {
-		$this->innerHtml[] = $el->writeHtml();
+		return $this->addInnerHtml($htmlItem->__toString());
 	}
 
 	/**
@@ -73,7 +76,7 @@ class Html {
 	}
 
 	protected function writeHtml() {
-		$output = '<'.$this->name;
+		$output = '<'.$this->type;
 		foreach($this->attributes as $key=>$val) {
 			$output .= ' '.$key. (($val !== null || strtolower($key) === 'value') ? '="'.$val.'"' : '');
 		}
@@ -81,7 +84,7 @@ class Html {
         foreach($this->innerHtml as $html) {
             $output.=$html;
         }
-		$output .= (($this->closingType === self::CLOSE_TYPE_TAG) ? sprintf('</%s>',$this->name) : '');
+		$output .= (($this->closingType === self::CLOSE_TYPE_TAG) ? sprintf('</%s>',$this->type) : '');
 		return $output;
 	}
 
@@ -102,12 +105,8 @@ class Html {
 		return $this->closingType;
 	}
 
-	public function getName() {
-		return $this->name;
-	}
-
-	public function getValue() {
-		return $this->value;
+	public function getType() {
+		return $this->type;
 	}
 
 	/**
@@ -120,4 +119,8 @@ class Html {
 	public function __toString() {
 		return $this->writeHtml();
 	}
+
+    public function getInnerHtml() {
+        return $this->innerHtml;
+    }
 }

--- a/src/UI/Html/HtmlForm.php
+++ b/src/UI/Html/HtmlForm.php
@@ -1,12 +1,13 @@
 <?php
 namespace Pecee\UI\Html;
+
 use Pecee\Http\Middleware\BaseCsrfVerifier;
 
 class HtmlForm extends Html {
+
 	public function __construct($name, $method, $action, $enctype) {
 		parent::__construct('form');
 		$this->closingType = self::CLOSE_TYPE_NONE;
-		$this->outerTag=true;
 		$this->addAttribute('name', $name);
 		$this->addAttribute('enctype', $enctype);
 		$this->addAttribute('method', $method);
@@ -16,5 +17,6 @@ class HtmlForm extends Html {
 		if(strtolower($method) === 'post') {
 			$this->addItem(new HtmlInput(BaseCsrfVerifier::POST_KEY, 'hidden', csrf_token()));
 		}
+
 	}
 }

--- a/src/UI/Html/HtmlImage.php
+++ b/src/UI/Html/HtmlImage.php
@@ -2,10 +2,12 @@
 namespace Pecee\UI\Html;
 
 class HtmlImage extends Html {
+
 	public function __construct($src, $alt = null) {
 		parent::__construct('img');
 		$this->closingType = self::CLOSE_TYPE_SELF;
 		$this->addAttribute('src', $src);
 		$this->addAttribute('alt', $alt);
 	}
+	
 }

--- a/src/UI/Html/HtmlInput.php
+++ b/src/UI/Html/HtmlInput.php
@@ -1,16 +1,18 @@
 <?php
 namespace Pecee\UI\Html;
 
+use Pecee\Str;
+
 class HtmlInput extends Html {
 
 	public function __construct($name, $type, $value = null) {
-		parent::__construct('input', $value);
+		parent::__construct('input');
 		$this->addAttribute('type', $type);
 		$this->addAttribute('name', $name);
 		$this->closingType = self::CLOSE_TYPE_SELF;
 
 		if($value !== null){
-			$this->addAttribute('value', $value);
+			$this->addAttribute('value', Str::htmlEntities($value));
 		}
 	}
 

--- a/src/UI/Html/HtmlLabel.php
+++ b/src/UI/Html/HtmlLabel.php
@@ -2,12 +2,15 @@
 namespace Pecee\UI\Html;
 
 class HtmlLabel extends Html {
-	public function __construct($name, $for) {
+
+	public function __construct($name, $for = null) {
 		parent::__construct('label');
-		if($for) {
+
+        if($for !== null) {
 			$this->addAttribute('for', $for);
 		}
-		//$this->closingTag = false;
-		$this->setInnerHtml($name);
+
+		$this->addInnerHtml($name);
 	}
+    
 }

--- a/src/UI/Html/HtmlScript.php
+++ b/src/UI/Html/HtmlScript.php
@@ -1,5 +1,6 @@
 <?php
 namespace Pecee\UI\Html;
+
 class HtmlScript extends Html {
 
 	public function __construct($src, $type = null) {

--- a/src/UI/Html/HtmlSelect.php
+++ b/src/UI/Html/HtmlSelect.php
@@ -4,16 +4,18 @@ namespace Pecee\UI\Html;
 class HtmlSelect extends Html {
 
 	protected $options;
-	public function __construct($name) {
+
+	public function __construct($name = null) {
 		parent::__construct('select');
-		$this->options=array();
-		if(!is_null($name)) {
+
+		$this->options = array();
+		if($name !== null) {
 			$this->addAttribute('name', $name);
 		}
 	}
 
 	public function addOption(HtmlSelectOption $option) {
-		$this->options[]=$option;
+		$this->options[] = $option;
 	}
 
 	public function getOptions() {
@@ -23,7 +25,7 @@ class HtmlSelect extends Html {
 	public function writeHtml() {
 		/* @var $option \Pecee\UI\Html\HtmlSelectOption */
 		foreach($this->options as $option) {
-			$this->setInnerHtml($option->writeHtml());
+			$this->addInnerHtml($option->writeHtml());
 		}
 		return parent::writeHtml();
 	}

--- a/src/UI/Html/HtmlSelectOption.php
+++ b/src/UI/Html/HtmlSelectOption.php
@@ -1,14 +1,18 @@
 <?php
 namespace Pecee\UI\Html;
+
 class HtmlSelectOption extends Html {
 
-	public function __construct($name, $value, $selected=false) {
-		parent::__construct('option', $value);
-		$this->addAttribute('value',$value);
-		if($selected) {
+	public function __construct($name, $value, $selected = false) {
+		parent::__construct('option');
+
+        $this->addAttribute('value', $value);
+
+		if($selected === true) {
 			$this->addAttribute('selected', 'selected');
 		}
-		$this->setInnerHtml($name);
+        
+		$this->addInnerHtml($name);
 	}
 
 }

--- a/src/UI/Html/HtmlTextarea.php
+++ b/src/UI/Html/HtmlTextarea.php
@@ -6,14 +6,13 @@ use Pecee\Str;
 class HtmlTextarea extends Html {
 
 	protected $value;
-	public function __construct($name, $rows, $cols, $value=null) {
+	public function __construct($name, $rows, $cols, $value = '') {
 		parent::__construct('textarea');
 		$this->value = Str::htmlEntities($value);
-		//$this->closingTag = false;
 		$this->addAttribute('name', $name);
 		$this->addAttribute('rows', $rows);
 		$this->addAttribute('cols', $cols);
-		$this->setInnerHtml($this->value);
+		$this->addInnerHtml($this->value);
 	}
 
 	public function getValue() {

--- a/src/UI/Tablist.php
+++ b/src/UI/Tablist.php
@@ -13,7 +13,7 @@ class Tablist {
 		$btn->addAttribute('href','#');
 		$btn->addAttribute('class','pecee-tablist');
 		$btn->addAttribute('data-id', $id);
-		$btn->setInnerHtml($value);
+		$btn->addInnerHtml($value);
 		return $btn;
 	}
 


### PR DESCRIPTION
## Changelog
- Added ```getAttribute($name)``` and ```getAttributes``` methods in ```Html``` class.
- Added support adding to the same attribute twice in ```Html``` class.
- Optimised ```Html``` classes.
- Fixed: ```getArray``` in Model class now returns `null` if no rows and not a collection or array if collection and no rows.
- Optimisation: changed `maxRows` column to `max_rows` in ```Model``` class.
- Changed `rowsPerPage` column to `rows_per_page` in ```Model``` class.
- Changed `hasNext` column to `has_next` in ```Model``` class.
- Changed `hasPrevious` column to `has_previous` in ```Model``` class.
- Changed `maxFields` column to `max_fields` in ```Model``` class.
- Fixed some properties not initialised as arrays in ```Model``` class.
- `getArray` method now only returns information about `has_next` and `has_previous` when it's a collection in ```Model``` class.
- Removed references to `user_id` in `UserReset` class.

## Notes
Because of the change in ```Html``` class, you might need to change any references to the method ```setInnerHtml``` to ```addInnerHtml```.