### PR TITLE
- Renamed createModel method to onInstanceCreate in Model class and a…

### DIFF
--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -100,8 +100,8 @@ abstract class Model implements \IteratorAggregate {
         return new ModelQueryBuilder($this, $table);
     }
 
-    public function createModel() {
-        return new static();
+    public function onInstanceCreate() {
+        
     }
 
     /**

--- a/src/Model/ModelData.php
+++ b/src/Model/ModelData.php
@@ -25,12 +25,8 @@ abstract class ModelData extends Model {
 		$this->data->$name = $value;
 	}
 
-	public function setRows(array $rows) {
-		parent::setRows($rows);
-
-        if(!$this->isCollection()) {
-            $this->fetchData();
-        }
+	public function onInstanceCreate() {
+        $this->fetchData();
 	}
 
 	public function setData(array $data) {

--- a/src/Model/ModelQueryBuilder.php
+++ b/src/Model/ModelQueryBuilder.php
@@ -24,11 +24,16 @@ class ModelQueryBuilder {
     }
 
     protected function createInstance(\stdClass $item) {
-        $model = $this->model->createModel();
+
+        $model = get_class($this->model);
+
+        $model = new $model();
 
         foreach($item as $key => $value) {
             $model->{$key} = $value;
         }
+
+        $model->onInstanceCreate($item);
 
         return $model;
     }


### PR DESCRIPTION
- Renamed createModel method to `onInstanceCreate` in Model class and are now first launched when `Model` has been initialized and data has been set.
- Fixed `ModelData` to make use of new `onInstanceCreate` method.
- Fixed `ModelQueryBuilder` to make use of new `onInstanceCreate` method.