### PR TITLE
V3 development

### DIFF
--- a/src/Model/ModelRelation.php
+++ b/src/Model/ModelRelation.php
@@ -105,9 +105,9 @@ abstract class ModelRelation
      */
     public function __call($name, $arguments)
     {
-        $result = $this->parent->{$name}(...$arguments);
+        $result = $this->related->{$name}(...$arguments);
 
-        if ($result === $this->parent) {
+        if ($result === $this->related) {
             return $this;
         }
 
@@ -116,7 +116,7 @@ abstract class ModelRelation
 
     public function __clone()
     {
-        $this->parent = clone $this->parent;
+        $this->related = clone $this->related;
     }
 
 }

--- a/src/Model/ModelRelation.php
+++ b/src/Model/ModelRelation.php
@@ -114,9 +114,4 @@ abstract class ModelRelation
         return $result;
     }
 
-    public function __clone()
-    {
-        $this->related = clone $this->related;
-    }
-
 }


### PR DESCRIPTION
- `ModelRelation`: fixed issue with call using parent model.
- `ModelRelation`: removed `__clone` as this is handled by `Model`.